### PR TITLE
feat: post 상세 조회

### DIFF
--- a/auth-library/src/main/kotlin/com/setung/auth/constant/LoginStatus.kt
+++ b/auth-library/src/main/kotlin/com/setung/auth/constant/LoginStatus.kt
@@ -1,0 +1,5 @@
+package com.setung.auth.constant
+
+enum class LoginStatus(val id: Long) {
+    ANONYMOUS(-1L);
+}

--- a/common-library/src/main/resources/application.properties
+++ b/common-library/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=common-library

--- a/gateway-service/src/main/kotlin/com/setung/gatewayservice/filter/JwtAuthGatewayFilter.kt
+++ b/gateway-service/src/main/kotlin/com/setung/gatewayservice/filter/JwtAuthGatewayFilter.kt
@@ -1,6 +1,7 @@
 package com.setung.gatewayservice.filter
 
 import com.setung.auth.constant.HttpHeader
+import com.setung.auth.constant.LoginStatus
 import com.setung.auth.jwt.JwtProvider
 import org.springframework.cloud.gateway.filter.GatewayFilter
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory
@@ -20,6 +21,13 @@ class JwtAuthGatewayFilter(
             val request = exchange.request
 
             if (!request.headers.containsKey(HttpHeaders.AUTHORIZATION)) {
+                if (config!!.allowAnonymous) {
+                    val anonymousRequest = request.mutate()
+                        .header(HttpHeader.USER_ID.value, LoginStatus.ANONYMOUS.id.toString())
+                        .build()
+                    return@GatewayFilter chain.filter(exchange.mutate().request(anonymousRequest).build())
+                }
+
                 return@GatewayFilter onError(exchange, "No authorization header")
             }
 
@@ -49,5 +57,7 @@ class JwtAuthGatewayFilter(
         return response.writeWith(Mono.just(buffer))
     }
 
-    class Config
+    class Config {
+        var allowAnonymous: Boolean = false
+    }
 }

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -3,12 +3,13 @@ server:
 spring:
   config:
     import:
-      - classpath:/users/user-service-routes.yml
+      - classpath:/routes/routes.yml
     activate:
       on-profile: default
   application:
     name: apigateway-service
-
+  main:
+    web-application-type: reactive
 
 jwt:
   enabled: true

--- a/gateway-service/src/main/resources/routes/routes.yml
+++ b/gateway-service/src/main/resources/routes/routes.yml
@@ -12,6 +12,18 @@ spring:
             - RewritePath=/user-service/(?<segment>.*), /$\{segment}
             - JwtAuthGatewayFilter
 
+        - id: user-service-allow-anonymous-get
+          uri: lb://USER-SERVICE
+          predicates:
+            - Path=/user-service/users/*
+            - Method=GET
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/user-service/(?<segment>.*), /$\{segment}
+            - name: JwtAuthGatewayFilter
+              args:
+                allowAnonymous: true
+
         - id: user-service-private-post
           uri: lb://USER-SERVICE
           predicates:
@@ -81,3 +93,37 @@ spring:
           filters:
             - RemoveRequestHeader=Cookie
             - RewritePath=/user-service/(?<segment>.*), /$\{segment}
+
+        - id: post-service-allow-anonymous-get
+          uri: lb://POST-SERVICE
+          predicates:
+            - Path=/post-service/posts/*,
+            - Method=GET
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/post-service/(?<segment>.*), /$\{segment}
+            - name: JwtAuthGatewayFilter
+              args:
+                allowAnonymous: true
+
+
+        - id: post-service-private-get
+          uri: lb://POST-SERVICE
+          predicates:
+            - Path=/post-service/posts/**, /post-service/posts
+            - Method=GET
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/post-service/(?<segment>.*), /$\{segment}
+            - JwtAuthGatewayFilter
+
+        - id: post-service-private-post
+          uri: lb://POST-SERVICE
+          predicates:
+            - Path=/post-service/posts
+            - Method=POST
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/post-service/(?<segment>.*), /$\{segment}
+            - JwtAuthGatewayFilter
+

--- a/post-service/build.gradle.kts
+++ b/post-service/build.gradle.kts
@@ -33,6 +33,9 @@ dependencies {
     implementation("org.springframework.cloud:spring-cloud-starter-bootstrap")
     implementation(project(":auth-library"))
     implementation(project(":common-library"))
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+    implementation("org.springframework.cloud:spring-cloud-starter-loadbalancer")
+    implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
 
     runtimeOnly("com.mysql:mysql-connector-j")
 

--- a/post-service/src/main/kotlin/com/setung/PostServiceApplication.kt
+++ b/post-service/src/main/kotlin/com/setung/PostServiceApplication.kt
@@ -2,10 +2,14 @@ package com.setung
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient
+import org.springframework.cloud.openfeign.EnableFeignClients
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableFeignClients
+@EnableDiscoveryClient
 class PostServiceApplication
 
 fun main(args: Array<String>) {

--- a/post-service/src/main/kotlin/com/setung/client/UserClient.kt
+++ b/post-service/src/main/kotlin/com/setung/client/UserClient.kt
@@ -1,0 +1,29 @@
+package com.setung.client
+
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestHeader
+import java.time.LocalDateTime
+
+@FeignClient("user-service")
+@Component
+interface UserClient {
+
+    @GetMapping("/users/{userId}")
+    fun getUser(@RequestHeader("user-id") loginUserId: Long, @PathVariable userId: Long): UserDto
+
+    @GetMapping("/users/hello")
+    fun hello(): String
+}
+
+data class UserDto(
+    val id: Long,
+    val email: String?,
+    val name: String,
+    val isVisible: Boolean,
+    val biography: String?,
+    val createdAt: LocalDateTime?,
+    val updatedAt: LocalDateTime?,
+)

--- a/post-service/src/main/kotlin/com/setung/controller/PostController.kt
+++ b/post-service/src/main/kotlin/com/setung/controller/PostController.kt
@@ -35,5 +35,19 @@ class PostController(
         @RequestPart("newImages", required = false) newImages: List<MultipartFile> = emptyList()
     ) =
         ResponseEntity(postService.update(loginUserId, postId, request, newImages), HttpStatus.OK)
+
+    @GetMapping("/{postId}")
+    fun findById(@LoginUser loginUserId: Long, @PathVariable postId: Long) =
+        ResponseEntity(postService.findPost(loginUserId, postId), HttpStatus.OK)
+
+    @GetMapping()
+    fun findAllByUserId(
+        @LoginUser loginUserId: Long,
+        @RequestParam(required = true) userId: Long,
+        @RequestParam(required = false) cursor: Long?,
+        @RequestParam(defaultValue = "10") size: Int
+    ) {
+
+    }
 }
 

--- a/post-service/src/main/kotlin/com/setung/dto/PostDetails.kt
+++ b/post-service/src/main/kotlin/com/setung/dto/PostDetails.kt
@@ -1,0 +1,38 @@
+package com.setung.dto
+
+import com.setung.entity.PostEntity
+import java.time.LocalDateTime
+
+data class PostDetails(
+    val id: Long,
+    val writerId: Long,
+    val contents: String?,
+    val images: List<PostImageDetails>?,
+    val postTags: List<PostTagDetails>?,
+    val createdAt: LocalDateTime?,
+    val updatedAt: LocalDateTime?
+) {
+    companion object {
+
+        fun ofPublic(post: PostEntity) = PostDetails(
+            id = post.id!!,
+            writerId = post.writerId,
+            contents = post.contents,
+            images = post.images.map { PostImageDetails(it.id!!, it.url) },
+            postTags = post.postTags.map { PostTagDetails(it.id!!, it.tag.name) },
+            createdAt = post.createdAt,
+            updatedAt = post.updatedAt
+        )
+
+        fun ofPrivate(post: PostEntity) = PostDetails(
+            id = post.id!!,
+            writerId = post.writerId,
+            contents = null,
+            images = null,
+            postTags = null,
+            createdAt = null,
+            updatedAt = null
+        )
+
+    }
+}

--- a/post-service/src/main/kotlin/com/setung/dto/PostImageDetails.kt
+++ b/post-service/src/main/kotlin/com/setung/dto/PostImageDetails.kt
@@ -1,0 +1,6 @@
+package com.setung.dto
+
+data class PostImageDetails(
+    val id: Long,
+    val url: String
+)

--- a/post-service/src/main/kotlin/com/setung/dto/PostTagDetails.kt
+++ b/post-service/src/main/kotlin/com/setung/dto/PostTagDetails.kt
@@ -1,0 +1,6 @@
+package com.setung.dto
+
+data class PostTagDetails(
+    val id: Long,
+    val name: String
+)

--- a/post-service/src/main/kotlin/com/setung/service/PostService.kt
+++ b/post-service/src/main/kotlin/com/setung/service/PostService.kt
@@ -1,5 +1,7 @@
 package com.setung.service
 
+import com.setung.client.UserClient
+import com.setung.dto.PostDetails
 import com.setung.dto.PostUpdateRequest
 import com.setung.dto.PostUploadRequest
 import com.setung.entity.PostEntity
@@ -18,7 +20,8 @@ import org.springframework.web.multipart.MultipartFile
 class PostService(
     private val postRepository: PostRepository,
     private val fileClient: FileClient,
-    private val tagRepository: TagRepository
+    private val tagRepository: TagRepository,
+    private val userClient: UserClient
 ) {
 
     @Transactional
@@ -58,5 +61,19 @@ class PostService(
         }
 
         post.update(request, fileUrls, tags)
+    }
+
+    fun findPost(loginUserId: Long, postId: Long): PostDetails {
+        val post = findById(postId)
+
+        if (loginUserId == post.writerId)
+            return PostDetails.ofPublic(post)
+
+        val writer = userClient.getUser(loginUserId, post.writerId)
+        if (writer.isVisible) {
+            return PostDetails.ofPublic(post)
+        }
+
+        return PostDetails.ofPrivate(post)
     }
 }

--- a/post-service/src/main/resources/bootstrap.yml
+++ b/post-service/src/main/resources/bootstrap.yml
@@ -3,7 +3,7 @@ spring:
     config:
       enabled: true
       uri: http://localhost:8888
-      name: user-service
+      name: post-service
 
 eureka:
   client:

--- a/post-service/src/test/kotlin/com/setung/controller/PostControllerTest.kt
+++ b/post-service/src/test/kotlin/com/setung/controller/PostControllerTest.kt
@@ -1,10 +1,11 @@
 package com.setung.controller
 
-import com.setung.dto.PostUpdateRequest
-import com.setung.dto.PostUploadRequest
+import com.setung.dto.*
 import com.setung.error.ForbiddenException
+import com.setung.error.NotFoundException
 import com.setung.service.PostService
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.doNothing
 import org.mockito.BDDMockito.given
@@ -12,115 +13,192 @@ import org.mockito.Mockito
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDateTime
 
 class PostControllerTest : AbstractControllerTest() {
 
     private val postService: PostService = Mockito.mock()
 
-    @Test
-    @DisplayName("[200] 업로드 성공 테스트")
-    fun followSuccessTest() {
-        val file = MockMultipartFile("file1", "test-image.jpg1", MediaType.IMAGE_JPEG_VALUE, "test image content".toByteArray())
-        val request = PostUploadRequest("contents", mutableSetOf("tag1", "tag2", "tag3"))
+    @Nested
+    inner class UploadTest {
 
-        given(postService.upload(1, request, mutableListOf(file))).willReturn(1)
+        @Test
+        @DisplayName("[200] 업로드 성공 테스트")
+        fun uploadSuccessTest() {
+            val file = MockMultipartFile("file1", "test-image.jpg1", MediaType.IMAGE_JPEG_VALUE, "test image content".toByteArray())
+            val request = PostUploadRequest("contents", mutableSetOf("tag1", "tag2", "tag3"))
 
-        mockMvc().perform(
-            MockMvcRequestBuilders
-                .multipart("/posts")
-                .file("images", file.bytes)
-                .file(
-                    MockMultipartFile(
-                        "request",
-                        "request.json",
-                        MediaType.APPLICATION_JSON_VALUE,
-                        objectMapper.writeValueAsString(request).toByteArray()
+            given(postService.upload(1, request, mutableListOf(file))).willReturn(1)
+
+            mockMvc().perform(
+                MockMvcRequestBuilders
+                    .multipart("/posts")
+                    .file("images", file.bytes)
+                    .file(
+                        MockMultipartFile(
+                            "request",
+                            "request.json",
+                            MediaType.APPLICATION_JSON_VALUE,
+                            objectMapper.writeValueAsString(request).toByteArray()
+                        )
                     )
+                    .header("user-id", "1")
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .accept(MediaType.APPLICATION_JSON)
+            )
+                .andExpect(status().isOk)
+        }
+    }
+
+    @Nested
+    inner class DeleteTest {
+
+        @Test
+        @DisplayName("[200] 삭제 성공 테스트")
+        fun deletePostSuccessTest() {
+            doNothing().`when`(postService).delete(1, 1)
+
+            mockMvc().perform(
+                MockMvcRequestBuilders
+                    .delete("/posts/{postId}", 1)
+                    .header("user-id", "1")
+            )
+                .andExpect(status().isOk)
+        }
+
+        @Test
+        @DisplayName("[403] 삭제 실패 테스트 - 다른 유저의 게시글 삭제 요청시 403 반환")
+        fun deletePostFailureTestWithOthers() {
+            given(postService.delete(1, 1)).willThrow(ForbiddenException::class.java)
+
+            mockMvc().perform(
+                MockMvcRequestBuilders
+                    .delete("/posts/{postId}", 1)
+                    .header("user-id", "1")
+            )
+                .andExpect(status().isForbidden)
+        }
+    }
+
+    @Nested
+    inner class UpdateTest {
+        @Test
+        @DisplayName("[200] 게시글 수정 성공 테스트")
+        fun updatePostSuccessTest() {
+            val request = PostUpdateRequest(
+                contents = "update",
+                newTags = mutableSetOf("1", "2"),
+                deletedPostTagIds = listOf(1, 2),
+                deletedImageIds = listOf(1, 2)
+            )
+
+            doNothing().`when`(postService).update(1, 1, request, emptyList())
+
+            mockMvc().perform(
+                MockMvcRequestBuilders
+                    .multipart("/posts/{postId}", 1)
+                    .file(
+                        MockMultipartFile(
+                            "request",
+                            "request.json",
+                            MediaType.APPLICATION_JSON_VALUE,
+                            objectMapper.writeValueAsString(request).toByteArray()
+                        )
+                    )
+                    .header("user-id", "1")
+            )
+                .andExpect(status().isOk)
+        }
+
+        @Test
+        @DisplayName("[403] 수정 실패 테스트 - 다른 유저의 게시글 수정 요청시 403 반환")
+        fun updatePostFailureTestWithOthers() {
+            val request = PostUpdateRequest(
+                contents = "update",
+                newTags = mutableSetOf("1", "2"),
+                deletedPostTagIds = listOf(1, 2),
+                deletedImageIds = listOf(1, 2)
+            )
+
+            given(postService.update(1, 1, request, emptyList())).willThrow(ForbiddenException::class.java)
+
+            mockMvc().perform(
+                MockMvcRequestBuilders
+                    .multipart("/posts/{postId}", 1)
+                    .file(
+                        MockMultipartFile(
+                            "request",
+                            "request.json",
+                            MediaType.APPLICATION_JSON_VALUE,
+                            objectMapper.writeValueAsString(request).toByteArray()
+                        )
+                    )
+                    .header("user-id", "1")
+            )
+                .andExpect(status().isForbidden)
+        }
+    }
+
+    @Nested
+    inner class FindTest {
+
+        @Test
+        @DisplayName("[200] 게시글 상세 보기 성공 테스트")
+        fun findSuccessTest() {
+            given(postService.findPost(1, 1)).willReturn(
+                PostDetails(
+                    id = 1L,
+                    writerId = 1L,
+                    contents = "contents",
+                    images = listOf(
+                        PostImageDetails(1L, "http://image.jpg")
+                    ),
+                    postTags = listOf(
+                        PostTagDetails(1L, "tag1")
+                    ),
+                    createdAt = LocalDateTime.now(),
+                    updatedAt = LocalDateTime.now()
                 )
-                .header("user-id", "1")
-                .contentType(MediaType.MULTIPART_FORM_DATA)
-                .accept(MediaType.APPLICATION_JSON)
-        )
-            .andExpect(status().isOk)
-    }
+            )
 
-    @Test
-    @DisplayName("[200] 삭제 성공 테스트")
-    fun deletePostSuccessTest() {
-        doNothing().`when`(postService).delete(1, 1)
+            mockMvc().perform(
+                MockMvcRequestBuilders
+                    .get("/posts/{postId}", 1)
+                    .header("user-id", "1")
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.writerId").value(1))
+                .andExpect(jsonPath("$.contents").value("contents"))
+                .andExpect(jsonPath("$.images[0].id").value(1))
+                .andExpect(jsonPath("$.images[0].url").value("http://image.jpg"))
+                .andExpect(jsonPath("$.postTags[0].id").value(1))
+                .andExpect(jsonPath("$.postTags[0].name").value("tag1"))
+        }
 
-        mockMvc().perform(
-            MockMvcRequestBuilders
-                .delete("/posts/{postId}", 1)
-                .header("user-id", "1")
-        )
-            .andExpect(status().isOk)
-    }
+        @Test
+        @DisplayName("[401] user-id 헤더 없이 요청")
+        fun findFailureTestWithoutUserIdHeader() {
+            mockMvc().perform(
+                MockMvcRequestBuilders
+                    .get("/posts/{postId}", 1)
+            )
+                .andExpect(status().isUnauthorized)
+        }
 
-    @Test
-    @DisplayName("[403] 삭제 실패 테스트 - 다른 유저의 게시글 삭제 요청시 403 반환")
-    fun deletePostFailureTestWithOthers() {
-        given(postService.delete(1, 1)).willThrow(ForbiddenException::class.java)
+        @Test
+        @DisplayName("[404] 존재하지 않는 게시글 요청")
+        fun findFailureTestWithNonExistentId() {
+            given(postService.findPost(1, -1)).willThrow(NotFoundException::class.java)
 
-        mockMvc().perform(
-            MockMvcRequestBuilders
-                .delete("/posts/{postId}", 1)
-                .header("user-id", "1")
-        )
-            .andExpect(status().isForbidden)
-    }
-
-    @Test
-    @DisplayName("[200] 게시글 수정 성공 테스트")
-    fun updatePostSuccessTest() {
-        val request = PostUpdateRequest(
-            contents = "update",
-            newTags = mutableSetOf("1", "2"),
-            deletedPostTagIds = listOf(1, 2),
-            deletedImageIds = listOf(1, 2)
-        )
-
-        doNothing().`when`(postService).update(1, 1, request, emptyList())
-
-        mockMvc().perform(
-            MockMvcRequestBuilders
-                .multipart("/posts/{postId}", 1)
-                .file(MockMultipartFile(
-                    "request",
-                    "request.json",
-                    MediaType.APPLICATION_JSON_VALUE,
-                    objectMapper.writeValueAsString(request).toByteArray()
-                ))
-                .header("user-id", "1")
-        )
-            .andExpect(status().isOk)
-    }
-
-    @Test
-    @DisplayName("[403] 수정 실패 테스트 - 다른 유저의 게시글 수정 요청시 403 반환")
-    fun updatePostFailureTestWithOthers() {
-        val request = PostUpdateRequest(
-            contents = "update",
-            newTags = mutableSetOf("1", "2"),
-            deletedPostTagIds = listOf(1, 2),
-            deletedImageIds = listOf(1, 2)
-        )
-
-        given(postService.update(1, 1, request, emptyList())).willThrow(ForbiddenException::class.java)
-
-        mockMvc().perform(
-            MockMvcRequestBuilders
-                .multipart("/posts/{postId}", 1)
-                .file(MockMultipartFile(
-                    "request",
-                    "request.json",
-                    MediaType.APPLICATION_JSON_VALUE,
-                    objectMapper.writeValueAsString(request).toByteArray()
-                ))
-                .header("user-id", "1")
-        )
-            .andExpect(status().isForbidden)
+            mockMvc().perform(
+                MockMvcRequestBuilders
+                    .get("/posts/{postId}", -1)
+            )
+                .andExpect(status().isUnauthorized)
+        }
     }
 
     override fun getController(): Any = PostController(postService)

--- a/post-service/src/test/kotlin/com/setung/service/PostServiceTest.kt
+++ b/post-service/src/test/kotlin/com/setung/service/PostServiceTest.kt
@@ -1,20 +1,29 @@
 package com.setung.service
 
+import com.setung.client.UserClient
+import com.setung.client.UserDto
 import com.setung.dto.PostUpdateRequest
 import com.setung.dto.PostUploadRequest
 import com.setung.entity.PostStatus
 import com.setung.error.ForbiddenException
+import com.setung.error.NotFoundException
 import com.setung.repo.PostRepository
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockMultipartFile
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 @SpringBootTest
 class PostServiceTest {
@@ -24,6 +33,9 @@ class PostServiceTest {
 
     @Autowired
     private lateinit var postRepository: PostRepository
+
+    @MockitoBean
+    private val userClient: UserClient = Mockito.mock()
 
     @Nested
     open inner class UploadTest {
@@ -131,7 +143,8 @@ class PostServiceTest {
         fun updateFailuresTestWithOthers() {
             val postId = postService.upload(1, PostUploadRequest("contents1", mutableSetOf()), emptyList())
             assertThrows<ForbiddenException> {
-                postService.update(2, postId,
+                postService.update(
+                    2, postId,
                     PostUpdateRequest(
                         "contensts", setOf(), listOf(), listOf()
                     ),
@@ -141,4 +154,99 @@ class PostServiceTest {
         }
     }
 
+    @Nested
+    open inner class FindTest {
+
+        @Test
+        @DisplayName("상세보기 성공 테스트 - 자신의 포스트 조회")
+        @Transactional
+        open fun findOwnDetailsSuccessTest() {
+            val request = PostUploadRequest("contents", mutableSetOf("tag1", "tag2", "tag3"))
+            val files =
+                mutableListOf(
+                    MockMultipartFile("file", "test-image.jpg", MediaType.IMAGE_JPEG_VALUE, byteArrayOf()),
+                )
+
+            val postId = postService.upload(1L, request, files)
+
+            val post = postService.findPost(1L, postId)
+
+            assertEquals(post.id, postId)
+            assertEquals(post.writerId, 1L)
+            assertNotNull(post.contents)
+            assertNotNull(post.postTags)
+            assertNotNull(post.images)
+        }
+
+        @Test
+        @DisplayName("상세보기 성공 테스트 - 공개 유저의 포스트 조회")
+        @Transactional
+        open fun findPublicDetailsSuccessTest() {
+            given(userClient.getUser(2L, 1L)).willReturn(
+                UserDto(
+                    id = 1L,
+                    isVisible = true,
+                    email = "tester@test.com",
+                    name = "name",
+                    biography = "biography",
+                    createdAt = LocalDateTime.now(),
+                    updatedAt = LocalDateTime.now()
+                )
+            )
+
+            val request = PostUploadRequest("contents", mutableSetOf("tag1", "tag2", "tag3"))
+            val files =
+                mutableListOf(
+                    MockMultipartFile("file", "test-image.jpg", MediaType.IMAGE_JPEG_VALUE, byteArrayOf()),
+                )
+
+            val postId = postService.upload(1L, request, files)
+
+            val post = postService.findPost(2L, postId)
+
+            assertEquals(post.id, postId)
+            assertEquals(post.writerId, 1L)
+            assertNotNull(post.contents)
+            assertNotNull(post.postTags)
+            assertNotNull(post.images)
+        }
+
+        @Test
+        @DisplayName("상세보기 성공 테스트 - 비공개 유저 포스트 조회")
+        fun findPrivateDetailsSuccessTest() {
+            given(userClient.getUser(2L, 1L)).willReturn(
+                UserDto(
+                    id = 1L,
+                    isVisible = false,
+                    email = null,
+                    name = "name",
+                    biography = null,
+                    createdAt = null,
+                    updatedAt = null,
+                )
+            )
+
+            val request = PostUploadRequest("contents", mutableSetOf("tag1", "tag2", "tag3"))
+            val files =
+                mutableListOf(
+                    MockMultipartFile("file", "test-image.jpg", MediaType.IMAGE_JPEG_VALUE, byteArrayOf()),
+                )
+
+            val postId = postService.upload(1L, request, files)
+
+            val post = postService.findPost(2L, postId)
+
+            assertEquals(post.id, postId)
+            assertEquals(post.writerId, 1L)
+            assertNull(post.contents)
+            assertNull(post.postTags)
+            assertNull(post.images)
+        }
+
+        @Test
+        @DisplayName("상세보기 실패 테스트 - 존재하지 않는 id")
+        fun findFailureTestWithNonExistentId() {
+            assertThrows<NotFoundException> { postService.findById(-1) }
+        }
+    }
 }

--- a/user-service/src/main/kotlin/com/setung/controller/UserController.kt
+++ b/user-service/src/main/kotlin/com/setung/controller/UserController.kt
@@ -32,8 +32,8 @@ class UserController(
         ResponseEntity(userService.findMe(userId), HttpStatus.OK)
 
     @GetMapping("/{userId}")
-    fun findUser(@PathVariable userId: Long) =
-        ResponseEntity(userService.findUser(userId), HttpStatus.OK)
+    fun findUser(@LoginUser loginUserId: Long, @PathVariable userId: Long) =
+        ResponseEntity(userService.findUser(loginUserId, userId), HttpStatus.OK)
 
     @PatchMapping("/me")
     fun update(@RequestBody request: UserUpdateRequest, @LoginUser userId: Long) =

--- a/user-service/src/main/kotlin/com/setung/dto/UserDto.kt
+++ b/user-service/src/main/kotlin/com/setung/dto/UserDto.kt
@@ -7,9 +7,10 @@ data class UserDto(
     val id: Long,
     val email: String?,
     val name: String,
+    val isVisible: Boolean,
     val biography: String?,
     val createdAt: LocalDateTime?,
-    val updatedAt: LocalDateTime?
+    val updatedAt: LocalDateTime?,
 ) {
     companion object {
 
@@ -20,6 +21,7 @@ data class UserDto(
             id = user.id!!,
             email = user.email,
             name = user.name,
+            isVisible = true,
             biography = user.biography,
             createdAt = user.createdAt,
             updatedAt = user.updatedAt
@@ -28,6 +30,7 @@ data class UserDto(
         fun ofPrivateUser(user: UserEntity) = UserDto(
             id = user.id!!,
             name = user.name,
+            isVisible = false,
             email = null,
             biography = null,
             createdAt = null,

--- a/user-service/src/main/kotlin/com/setung/repo/FollowRepository.kt
+++ b/user-service/src/main/kotlin/com/setung/repo/FollowRepository.kt
@@ -3,4 +3,7 @@ package com.setung.repo
 import com.setung.entity.FollowEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface FollowRepository : JpaRepository<FollowEntity, Long>
+interface FollowRepository : JpaRepository<FollowEntity, Long> {
+
+    fun findByRequesterIdAndTargetId(requesterId: Long, targetId: Long): FollowEntity?
+}

--- a/user-service/src/main/kotlin/com/setung/service/FollowService.kt
+++ b/user-service/src/main/kotlin/com/setung/service/FollowService.kt
@@ -66,4 +66,7 @@ class FollowService(
         followRepository.delete(follow)
     }
 
+    fun findByRequesterIdAndTargetId(requesterId: Long, targetId: Long): FollowEntity? {
+        return followRepository.findByRequesterIdAndTargetId(requesterId, targetId)
+    }
 }

--- a/user-service/src/main/kotlin/com/setung/service/UserService.kt
+++ b/user-service/src/main/kotlin/com/setung/service/UserService.kt
@@ -1,16 +1,15 @@
 package com.setung.service
 
+import com.setung.auth.constant.LoginStatus
 import com.setung.auth.jwt.JwtProvider
 import com.setung.dto.*
-import com.setung.entity.EmailCodeType
-import com.setung.entity.ProfileImage
-import com.setung.entity.UserEntity
-import com.setung.entity.UserStatus
+import com.setung.entity.*
 import com.setung.error.DuplicateEmailException
 import com.setung.error.InvalidPasswordException
 import com.setung.error.NotFoundException
 import com.setung.file.FileClient
 import com.setung.mail.EmailClient
+import com.setung.repo.FollowRepository
 import com.setung.repo.ProfileImageRepository
 import com.setung.repo.UserRepository
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -26,7 +25,8 @@ class UserService(
     val emailService: EmailClient,
     val jwtProvider: JwtProvider,
     val fileClient: FileClient,
-    val profileImageRepository: ProfileImageRepository
+    val profileImageRepository: ProfileImageRepository,
+    private val followRepository: FollowRepository
 ) {
 
     fun signup(request: UserSignupRequest): Long {
@@ -86,8 +86,20 @@ class UserService(
     fun findMe(id: Long) =
         UserDto.ofPublicUser(findById(id))
 
-    fun findUser(id: Long) =
-        UserDto.of(findById(id))
+    fun findUser(loginUserId: Long = LoginStatus.ANONYMOUS.id, id: Long): UserDto {
+        val user = findById(id)
+        if (user.isPrivate && loginUserId != id) {
+            if (loginUserId == LoginStatus.ANONYMOUS.id) {
+                return UserDto.ofPrivateUser(user)
+            } else {
+                val follow = followRepository.findByRequesterIdAndTargetId(loginUserId, id)
+                if (follow == null || follow.status != FollowStatus.ACCEPTED)
+                    return UserDto.ofPrivateUser(user)
+            }
+        }
+
+        return UserDto.ofPublicUser(findById(id))
+    }
 
     fun findById(id: Long) =
         userRepository.findByIdAndStatus(id, UserStatus.NORMAL)

--- a/user-service/src/main/resources/bootstrap.yml
+++ b/user-service/src/main/resources/bootstrap.yml
@@ -11,7 +11,7 @@ eureka:
     fetch-registry: true
     service-url:
       defaultZone: http://localhost:8761/eureka
-    enabled: false
+    enabled: true
   instance:
     instance-id: ${spring.application.name}-${random.value}
     prefer-ip-address: true

--- a/user-service/src/test/kotlin/com/setung/controller/UserControllerTest.kt
+++ b/user-service/src/test/kotlin/com/setung/controller/UserControllerTest.kt
@@ -1,5 +1,6 @@
 package com.setung.controller
 
+import com.setung.auth.constant.LoginStatus
 import com.setung.dto.*
 import com.setung.entity.EmailCodeType
 import com.setung.error.*
@@ -240,10 +241,12 @@ class UserControllerTest : AbstractControllerTest() {
         @Test
         @DisplayName("[404] 삭제 후 계정 조회 테스트")
         fun findDeletedUserFailureTest() {
-            given(userService.findUser(1)).willThrow(NotFoundException("Could not find user"))
+            given(userService.findUser(LoginStatus.ANONYMOUS.id, 1)).willThrow(NotFoundException("Could not find user"))
 
             mockMvc().perform(
-                MockMvcRequestBuilders.get("/users/1").header("user-id", 1).contentType(MediaType.APPLICATION_JSON)
+                MockMvcRequestBuilders.get("/users/1")
+                    .header("user-id", LoginStatus.ANONYMOUS.id)
+                    .contentType(MediaType.APPLICATION_JSON)
             ).andExpect(status().isNotFound)
         }
     }
@@ -260,6 +263,7 @@ class UserControllerTest : AbstractControllerTest() {
                     name = "name",
                     email = "tester@test.com",
                     biography = "biography",
+                    isVisible = true,
                     createdAt = LocalDateTime.now(),
                     updatedAt = LocalDateTime.now()
                 )
@@ -281,19 +285,22 @@ class UserControllerTest : AbstractControllerTest() {
         @Test
         @DisplayName("[200] 유저 조회")
         fun findUserTest() {
-            given(userService.findUser(1)).willReturn(
+            given(userService.findUser(LoginStatus.ANONYMOUS.id, 1)).willReturn(
                 UserDto(
                     id = 1L,
                     name = "name",
                     email = "tester@test.com",
                     biography = "biography",
+                    isVisible = true,
                     createdAt = LocalDateTime.now(),
                     updatedAt = LocalDateTime.now()
                 )
             )
 
             mockMvc().perform(
-                MockMvcRequestBuilders.get("/users/1").contentType(MediaType.APPLICATION_JSON)
+                MockMvcRequestBuilders.get("/users/1")
+                    .header("user-id", LoginStatus.ANONYMOUS.id)
+                    .contentType(MediaType.APPLICATION_JSON)
             ).andExpect(status().isOk)
         }
 

--- a/user-service/src/test/kotlin/com/setung/service/UserServiceTest.kt
+++ b/user-service/src/test/kotlin/com/setung/service/UserServiceTest.kt
@@ -10,6 +10,7 @@ import com.setung.error.InvalidPasswordException
 import com.setung.error.NotFoundException
 import com.setung.repo.UserRepository
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -196,23 +197,36 @@ class UserServiceTest @Autowired constructor(
         @DisplayName("자신 조회 - private 상태도 정상으로 조회 가능")
         fun findMePrivateTest() {
             val user = userService.findMe(6)
+
+            assertTrue(user.isVisible)
             assertThat(user.email).isNotNull()
         }
 
         @Test
         @DisplayName("유저 조회 - public")
         fun findUserPublicTest() {
-            val user = userService.findUser(5)
+            val user = userService.findUser(id = 5)
+
+            assertTrue(user.isVisible)
             assertThat(user.email).isNotNull()
         }
 
         @Test
         @DisplayName("유저 조회 - private")
         fun findUserPrivateTest() {
-            val user = userService.findUser(6)
+            val user = userService.findUser(id = 6)
+
+            assertFalse(user.isVisible)
             assertThat(user.email).isNull()
         }
 
+        @Test
+        @DisplayName("private 유저 조회 - 팔로우 승인된 유저의 요청시 visible true")
+        fun findUserPrivateTestWithFollowAccepted() {
+            val user = userService.findUser(1, 10)
+
+            assertTrue(user.isVisible)
+        }
     }
 
     @Nested

--- a/user-service/src/test/resources/application.yml
+++ b/user-service/src/test/resources/application.yml
@@ -22,5 +22,6 @@ spring:
       data-locations: classpath:sql/data/*.sql
 
 jwt:
+  enabled: true
   secret: 9F8xvM1QK5Pj1W7RZyG+2tOQVp3X6LbBgNT9aFovRj0=
   expiration: 3600000

--- a/user-service/src/test/resources/sql/data/follow.sql
+++ b/user-service/src/test/resources/sql/data/follow.sql
@@ -6,4 +6,5 @@ VALUES
     (4, 2,7, 'PENDING', sysdate(), sysdate()),
     (5, 2,8, 'ACCEPTED', sysdate(), sysdate()),
     (6, 7,8, 'PENDING', sysdate(), sysdate()),
-    (7, 1,2, 'PENDING', sysdate(), sysdate());
+    (7, 1,2, 'PENDING', sysdate(), sysdate()),
+    (8, 1,10, 'ACCEPTED', sysdate(), sysdate());

--- a/user-service/src/test/resources/sql/data/user.sql
+++ b/user-service/src/test/resources/sql/data/user.sql
@@ -8,4 +8,5 @@ VALUES
     (6, 'name', 'private_tester@test.com', true, '$2a$10$6ipZUZWDYEVXa0jwgF/L2efyVMnzYs8r/s4eSoQ.gI9qFSICRDn5O', 'NORMAL', sysdate(), sysdate()),
     (7, 'follow_test', 'follow_public_tester@test.com', false, '$2a$10$6ipZUZWDYEVXa0jwgF/L2efyVMnzYs8r/s4eSoQ.gI9qFSICRDn5O', 'NORMAL', sysdate(), sysdate()),
     (8, 'follow_test', 'follow_private_tester@test.com', true, '$2a$10$6ipZUZWDYEVXa0jwgF/L2efyVMnzYs8r/s4eSoQ.gI9qFSICRDn5O', 'NORMAL', sysdate(), sysdate()),
-    (9, 'profile-image', 'profile-image_tester@test.com', true, '$2a$10$6ipZUZWDYEVXa0jwgF/L2efyVMnzYs8r/s4eSoQ.gI9qFSICRDn5O', 'NORMAL', sysdate(), sysdate());
+    (9, 'profile-image', 'profile-image_tester@test.com', true, '$2a$10$6ipZUZWDYEVXa0jwgF/L2efyVMnzYs8r/s4eSoQ.gI9qFSICRDn5O', 'NORMAL', sysdate(), sysdate()),
+    (10, 'name', 'find-private@test.com', true, '$2a$10$6ipZUZWDYEVXa0jwgF/L2efyVMnzYs8r/s4eSoQ.gI9qFSICRDn5O', 'NORMAL', sysdate(), sysdate());


### PR DESCRIPTION
- JwtAuthGatewayFilter 개선
  - allowAnonymous 설정을 통해 익명 사용자의 인증 여부 결정

- Post-service에서 유저를 조회할 UserServiceClient를 feign client로 구현

- 게시글 작성자의 공개 여부에 따른 조회 방식 적용
  - 공개 유저의 게시글은 모든 사용자가 조회 가능
  - 비공개 유저의 게시글은 본인 또는 팔로우 승인된 사용자만 조회 가능